### PR TITLE
max depth constraint on rules

### DIFF
--- a/greenideas/grammar_engine.py
+++ b/greenideas/grammar_engine.py
@@ -53,7 +53,7 @@ class GrammarEngine:
         children = []
         for _, spec in enumerate(rule.expansion):
             if isinstance(spec, ExpansionSpec):
-                child = POSNode(type=spec.pos_type)
+                child = POSNode(type=spec.pos_type, depth=node.depth + 1)
                 for attr_type, constraint in spec.attribute_constraints.items():
                     if constraint is not None:
                         if constraint == INHERIT:

--- a/greenideas/parts_of_speech/pos_node.py
+++ b/greenideas/parts_of_speech/pos_node.py
@@ -10,6 +10,7 @@ class POSNode:
     type: POSType
     children: List[Self] = field(default_factory=list)
     attributes: AttributeSet = field(default_factory=AttributeSet)
+    depth: int = 0
 
     def __str__(self):
         children = (
@@ -17,4 +18,4 @@ class POSNode:
             if self.children
             else None
         )
-        return f"{self.type.name}{children if children else ''}"
+        return f"{self.type.name}:{children if children else ''}"

--- a/greenideas/rules/default_english_rules/s_expansions.py
+++ b/greenideas/rules/default_english_rules/s_expansions.py
@@ -86,6 +86,7 @@ s__s_conj_s = GrammarRule(
         ExpansionSpec(POSType.S),
     ],
     weight=0.2,
+    ignore_after_depth=1,
 )
 
 s__s_sub_s = GrammarRule(
@@ -96,6 +97,7 @@ s__s_sub_s = GrammarRule(
         ExpansionSpec(POSType.S),
     ],
     weight=0.2,
+    ignore_after_depth=1,
 )
 
 s_expansions = [

--- a/greenideas/rules/default_english_rules/vp_expansions.py
+++ b/greenideas/rules/default_english_rules/vp_expansions.py
@@ -71,7 +71,7 @@ vp2__v_npAcc = GrammarRule(
     ],
 )
 
-# VP3 -> V NP.Obj NP.Nom
+# VP3 -> V NP.Obj NP.Obj
 vp3__v_npAcc_npNom = GrammarRule(
     SourceSpec(POSType.VP, {AttributeType.VALENCY: Valency.TRIVALENT}),
     [
@@ -95,7 +95,7 @@ vp3__v_npAcc_npNom = GrammarRule(
         ExpansionSpec(
             POSType.NP,
             {
-                AttributeType.CASE: Case.NOMINATIVE,
+                AttributeType.CASE: Case.OBJECTIVE,
             },
         ),
     ],

--- a/greenideas/rules/grammar_rule.py
+++ b/greenideas/rules/grammar_rule.py
@@ -12,12 +12,14 @@ class GrammarRule:
         source: ExpansionSpec,
         expansion: list[ExpansionSpec],
         weight: float = 1.0,
+        ignore_after_depth: int = 0,
     ):
         self.source = source
         self.pos = source.pos_type
         self.source_constraints = source.attribute_constraints
         self.expansion = expansion
         self.weight = weight
+        self.ignore_after_depth = ignore_after_depth
 
     def validate_attribute_constraint(
         self, pos_type: POSType, attr: AttributeType, value
@@ -39,7 +41,14 @@ class GrammarRule:
         for attr_type, constraint in self.source_constraints.items():
             if isinstance(constraint, list):
                 if node.attributes.get(attr_type) not in constraint:
+                    print(f"{node.attributes.get(attr_type)} not in {constraint}")
                     return False
             elif node.attributes.get(attr_type) != constraint:
+                print(f"{node.attributes.get(attr_type)} != {constraint}")
                 return False
+        if self.ignore_after_depth and node.depth >= self.ignore_after_depth:
+            print(
+                f"node depth {node.depth} >= ignore after depth {self.ignore_after_depth}"
+            )
+            return False
         return True

--- a/tests/test_grammar_rules.py
+++ b/tests/test_grammar_rules.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from greenideas.attributes.attribute_type import AttributeType
+from greenideas.attributes.number import Number
+from greenideas.parts_of_speech.pos_node import POSNode
+from greenideas.parts_of_speech.pos_types import POSType
+from greenideas.rules.expansion_spec import ExpansionSpec
+from greenideas.rules.grammar_rule import GrammarRule
+from greenideas.rules.source_spec import SourceSpec
+
+
+class TestGrammarRule(TestCase):
+    def setUp(self):
+        self.np__det_n = GrammarRule(
+            SourceSpec(POSType.NP, {AttributeType.NUMBER: Number.SINGULAR}),
+            [
+                ExpansionSpec(POSType.Det, {AttributeType.NUMBER: Number.SINGULAR}),
+                ExpansionSpec(POSType.Det, {AttributeType.NUMBER: Number.SINGULAR}),
+            ],
+            weight=1.0,
+            ignore_after_depth=2,
+        )
+
+    def test_is_applicable_to_node_attribute_mismatch(self):
+        node = POSNode(
+            POSType.NP, attributes={AttributeType.NUMBER: Number.PLURAL}, depth=1
+        )
+        self.assertFalse(self.np__det_n.is_applicable_to_node(node))
+
+    def test_is_applicable_to_node_attribute_match(self):
+        node = POSNode(
+            POSType.NP, attributes={AttributeType.NUMBER: Number.SINGULAR}, depth=1
+        )
+        self.assertTrue(self.np__det_n.is_applicable_to_node(node))
+
+    def test_is_applicable_to_node_depth_exceeded(self):
+        node = POSNode(
+            POSType.NP, attributes={AttributeType.NUMBER: Number.SINGULAR}, depth=3
+        )
+        self.assertFalse(self.np__det_n.is_applicable_to_node(node))


### PR DESCRIPTION
Add a depth constraint on rules, which can be used to avoid excessively long sentences/deep embeddings