### PR TITLE
Avoid punctuation pileup

### DIFF
--- a/greenideas/rules/default_english_rules/expansions/npNodet_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/npNodet_expansions.py
@@ -58,7 +58,7 @@ npNodet__adjp_n = GrammarRule(
 )
 
 # NP_NoDet -> N RelClause
-npNodet__n_relclause = GrammarRule(
+npNodet__n_relclause_no_commas = GrammarRule(
     SourceSpec(DefaultEnglishPOSType.NP_NoDet),
     [
         ExpansionSpec(
@@ -76,8 +76,6 @@ npNodet__n_relclause = GrammarRule(
                 DefaultEnglishAttributeType.NUMBER: INHERIT,
                 DefaultEnglishAttributeType.PERSON: INHERIT,
             },
-            pre_punctuation=",",
-            post_punctuation=",",
         ),
     ],
     weight=0.2,
@@ -114,6 +112,6 @@ npNodet_expansions = [
     npNodet__n,
     np_nodet__adjp_np_nodet,
     npNodet__adjp_n,
-    npNodet__n_relclause,
+    npNodet__n_relclause_no_commas,
     npNodet__n_relclause_commas,
 ]

--- a/greenideas/twaddle/formatting_context.py
+++ b/greenideas/twaddle/formatting_context.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class FormattingContext:
+    value: str = ""
+    needs_space: bool = False
+    queued_punctuation: Optional[str] = None

--- a/greenideas/twaddle/twaddle_formatter.py
+++ b/greenideas/twaddle/twaddle_formatter.py
@@ -54,9 +54,13 @@ class TwaddleFormatter:
             twaddle_string += self.format_node(node, context)
         else:
             for child in node.children:
+                if context.queued_punctuation:
+                    twaddle_string += context.queued_punctuation
+                    context.queued_punctuation = None
                 twaddle_string += self.format(child, context).value
                 context.needs_space = child.space_follows
-                context.queued_punctuation = child.post_punctuation
+                if child.post_punctuation:
+                    context.queued_punctuation = child.post_punctuation
         if node.post_punctuation:
             context.queued_punctuation = node.post_punctuation
         return FormattingContext(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "greenideas"
-version = "0.8.0"
+version = "0.9.0"
 description = "A package to generate grammatically valid but semantically nonsensical English sentences."
 authors = [
     {name = "Chris Hengler",email = "chrysics@gmail.com"}

--- a/tests/test_twaddle_formatter.py
+++ b/tests/test_twaddle_formatter.py
@@ -160,6 +160,64 @@ class TestTwaddleFormatter(unittest.TestCase):
         result = self.formatter.format_as_sentence(sentence)
         self.assertEqual(result, expected_template)
 
+    def test_parent_node_post_punctuation(self):
+        det = POSNode(
+            type=DefaultEnglishPOSType.Det,
+            attributes={DefaultEnglishAttributeType.NUMBER: Number.SINGULAR},
+        )
+        noun = POSNode(
+            type=DefaultEnglishPOSType.Noun,
+            attributes={DefaultEnglishAttributeType.NUMBER: Number.SINGULAR},
+        )
+        verb = POSNode(
+            type=DefaultEnglishPOSType.Verb,
+            attributes={
+                DefaultEnglishAttributeType.NUMBER: Number.SINGULAR,
+                DefaultEnglishAttributeType.PERSON: Person.THIRD,
+                DefaultEnglishAttributeType.TENSE: Tense.PRESENT,
+                DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
+            },
+        )
+        rel_pron = POSNode(
+            type=DefaultEnglishPOSType.RelativePron,
+            attributes={DefaultEnglishAttributeType.ANIMACY: Animacy.ANIMATE},
+        )
+        rel_clause_verb = POSNode(
+            type=DefaultEnglishPOSType.Verb,
+            attributes={
+                DefaultEnglishAttributeType.NUMBER: Number.SINGULAR,
+                DefaultEnglishAttributeType.PERSON: Person.THIRD,
+                DefaultEnglishAttributeType.TENSE: Tense.PAST,
+                DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
+            },
+        )
+        rel_clause = POSNode(
+            type=DefaultEnglishPOSType.RelClause,
+            children=[rel_pron, rel_clause_verb],
+            pre_punctuation=",",
+            post_punctuation=",",
+        )
+        noun_phrase_with_rel_clause = POSNode(
+            type=DefaultEnglishPOSType.NP, children=[det, noun, rel_clause]
+        )
+        noun_phrase = POSNode(type=DefaultEnglishPOSType.NP, children=[det, noun])
+        verb_phrase = POSNode(
+            type=DefaultEnglishPOSType.VP,
+            children=[verb, noun_phrase],
+        )
+
+        sentence = POSNode(
+            type=DefaultEnglishPOSType.S,
+            children=[noun_phrase_with_rel_clause, verb_phrase],
+            post_punctuation=".",
+        )
+        result = self.formatter.format_as_sentence(sentence)
+        expected_template = (
+            "[case:sentence]<det.sg> <noun.sg>, <rel-animate> <verb-monovalent.past>, "
+            "<verb-monovalent.s> <det.sg> <noun.sg>."
+        )
+        self.assertEqual(result, expected_template)
+
     def test_punctuation_and_spacing_defined_on_intermediate_nodes(self):
         det = POSNode(
             type=DefaultEnglishPOSType.Det,
@@ -241,9 +299,6 @@ class TestTwaddleFormatter(unittest.TestCase):
             children=[verb, noun_phrase_with_rel_clause],
         )
 
-        rel_clause = POSNode(
-            type=DefaultEnglishPOSType.RelClause,
-        )
         sentence = POSNode(
             type=DefaultEnglishPOSType.S,
             children=[noun_phrase, verb_phrase],

--- a/tests/test_twaddle_formatter.py
+++ b/tests/test_twaddle_formatter.py
@@ -1,6 +1,7 @@
 import unittest
 
 from greenideas.parts_of_speech.pos_node import POSNode
+from greenideas.rules.default_english_rules.attributes.animacy import Animacy
 from greenideas.rules.default_english_rules.attributes.default_english_attribute_type import (
     DefaultEnglishAttributeType,
 )
@@ -48,7 +49,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             type=DefaultEnglishPOSType.S, children=[noun_phrase, verb_phrase]
         )
         expected_template = "<det.sg> <noun.sg> <verb-monovalent.s> <det.sg> <noun.sg>"
-        result = self.formatter.format(sentence)
+        result = self.formatter.format(sentence).value
         self.assertEqual(result, expected_template)
 
     def test_format_as_sentence(self):
@@ -117,6 +118,22 @@ class TestTwaddleFormatter(unittest.TestCase):
         result = self.formatter.format_as_sentence(node)
         self.assertEqual(result, expected_template)
 
+    def test_terminal_punctuation_not_top_level(self):
+        verb = POSNode(
+            type=DefaultEnglishPOSType.Verb,
+            attributes={
+                DefaultEnglishAttributeType.NUMBER: Number.SINGULAR,
+                DefaultEnglishAttributeType.PERSON: Person.THIRD,
+                DefaultEnglishAttributeType.TENSE: Tense.PRESENT,
+                DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
+            },
+            post_punctuation="!",
+        )
+        sentence = POSNode(type=DefaultEnglishPOSType.S, children=[verb])
+        expected_template = "[case:sentence]<verb-monovalent.s>!"
+        result = self.formatter.format_as_sentence(sentence)
+        self.assertEqual(result, expected_template)
+
     def test_with_spacing_and_punctuation(self):
         det = POSNode(
             type=DefaultEnglishPOSType.Det,
@@ -176,6 +193,67 @@ class TestTwaddleFormatter(unittest.TestCase):
         )
         expected_template = "[case:sentence]!<det.sg> <noun.sg>, <verb-monovalent.s> <det.sg> <noun.sg>?"
         result = self.formatter.format_as_sentence(sentence)
+        self.assertEqual(result, expected_template)
+
+    def test_post_punctuation_pileup(self):
+        det = POSNode(
+            type=DefaultEnglishPOSType.Det,
+            attributes={DefaultEnglishAttributeType.NUMBER: Number.SINGULAR},
+        )
+        noun = POSNode(
+            type=DefaultEnglishPOSType.Noun,
+            attributes={DefaultEnglishAttributeType.NUMBER: Number.SINGULAR},
+        )
+        verb = POSNode(
+            type=DefaultEnglishPOSType.Verb,
+            attributes={
+                DefaultEnglishAttributeType.NUMBER: Number.SINGULAR,
+                DefaultEnglishAttributeType.PERSON: Person.THIRD,
+                DefaultEnglishAttributeType.TENSE: Tense.PRESENT,
+                DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
+            },
+        )
+        rel_pron = POSNode(
+            type=DefaultEnglishPOSType.RelativePron,
+            attributes={DefaultEnglishAttributeType.ANIMACY: Animacy.ANIMATE},
+        )
+        rel_clause_verb = POSNode(
+            type=DefaultEnglishPOSType.Verb,
+            attributes={
+                DefaultEnglishAttributeType.NUMBER: Number.SINGULAR,
+                DefaultEnglishAttributeType.PERSON: Person.THIRD,
+                DefaultEnglishAttributeType.TENSE: Tense.PAST,
+                DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
+            },
+        )
+        rel_clause = POSNode(
+            type=DefaultEnglishPOSType.RelClause,
+            children=[rel_pron, rel_clause_verb],
+            pre_punctuation=",",
+            post_punctuation=",",
+        )
+        noun_phrase = POSNode(type=DefaultEnglishPOSType.NP, children=[det, noun])
+        noun_phrase_with_rel_clause = POSNode(
+            type=DefaultEnglishPOSType.NP, children=[det, noun, rel_clause]
+        )
+        verb_phrase = POSNode(
+            type=DefaultEnglishPOSType.VP,
+            children=[verb, noun_phrase_with_rel_clause],
+        )
+
+        rel_clause = POSNode(
+            type=DefaultEnglishPOSType.RelClause,
+        )
+        sentence = POSNode(
+            type=DefaultEnglishPOSType.S,
+            children=[noun_phrase, verb_phrase],
+            post_punctuation=".",
+        )
+        result = self.formatter.format_as_sentence(sentence)
+        expected_template = (
+            "[case:sentence]<det.sg> <noun.sg> <verb-monovalent.s> <det.sg> "
+            "<noun.sg>, <rel-animate> <verb-monovalent.past>."
+        )
         self.assertEqual(result, expected_template)
 
 


### PR DESCRIPTION
Rules with post-punctuation occurring at the end of an expansion could lead to punctuation pileups such as

> Cats, that were read an owl, that opens a writer, who is closed,,, don't wait.

> Hard knives had been kneading these otters, that disappeared,.

Fix: let punctuation bubble-up through the recursive formatting, replacing any queued punctuation if a higher level node also terminates with some other punctuation at the same place, only printing when the next part of speech is added.