### PR TITLE
Fix auxp expansion issue

### DIFF
--- a/greenideas/rules/default_english_rules/default_rules.py
+++ b/greenideas/rules/default_english_rules/default_rules.py
@@ -32,14 +32,14 @@ from greenideas.rules.default_english_rules.expansions.utterance_expansions impo
 from greenideas.rules.default_english_rules.expansions.vp_expansions import (
     vp_expansions,
 )
-from greenideas.rules.default_english_rules.expansions.vpAfterFrontedAux_expansions import (
-    vpAfterFA_expansions,
-)
 from greenideas.rules.default_english_rules.expansions.vpAfterModal_expansions import (
     vpAfterModal_expansions,
 )
 from greenideas.rules.default_english_rules.expansions.vpBare_expansions import (
     vpBare_expansions,
+)
+from greenideas.rules.default_english_rules.expansions.vpExistingAux_expansions import (
+    vpExistingAux_expansions,
 )
 from greenideas.rules.default_english_rules.expansions.vpPassive_expansions import (
     vp_passive_expansions,
@@ -64,7 +64,7 @@ default_rules.add_rules(pp_expansions)
 default_rules.add_rules(question_expansions)
 default_rules.add_rules(relC_expansions)
 default_rules.add_rules(vp_expansions)
-default_rules.add_rules(vpAfterFA_expansions)
+default_rules.add_rules(vpExistingAux_expansions)
 default_rules.add_rules(vpAfterModal_expansions)
 default_rules.add_rules(vpBare_expansions)
 default_rules.add_rules(vp_passive_expansions)

--- a/greenideas/rules/default_english_rules/expansions/auxP_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/auxP_expansions.py
@@ -31,7 +31,7 @@ auxp__auxFinite_vpParticiple = GrammarRule(
             },
         ),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,

--- a/greenideas/rules/default_english_rules/expansions/auxP_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/auxP_expansions.py
@@ -10,8 +10,7 @@ from greenideas.rules.expansion_spec import INHERIT, ExpansionSpec
 from greenideas.rules.grammar_rule import GrammarRule
 from greenideas.rules.source_spec import SourceSpec
 
-# VP -> Aux_finite VP.participle
-# placeholder, need to add additional attributes before implementing this correctly
+# VP -> Aux_finite VP
 auxp__auxFinite_vpParticiple = GrammarRule(
     SourceSpec(
         DefaultEnglishPOSType.AuxP,
@@ -32,15 +31,15 @@ auxp__auxFinite_vpParticiple = GrammarRule(
             },
         ),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP,
+            DefaultEnglishPOSType.VP_AfterFrontedAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
-                DefaultEnglishAttributeType.NUMBER: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
-                DefaultEnglishAttributeType.PERSON: INHERIT,
+                DefaultEnglishAttributeType.VOICE: INHERIT,
             },
         ),
     ],
+    weight=1000,
 )
 
 auxPerfprog__auxFinite_vpParticiple = GrammarRule(

--- a/greenideas/rules/default_english_rules/expansions/q_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/q_expansions.py
@@ -74,7 +74,7 @@ q__auxFinite_np_vp = GrammarRule(
             },
         ),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
@@ -109,7 +109,7 @@ qProg__be_np_vp = GrammarRule(
             },
         ),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
@@ -146,7 +146,7 @@ qSimplePast__be_np_vpAfterAF = GrammarRule(
             },
         ),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,

--- a/greenideas/rules/default_english_rules/expansions/s_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/s_expansions.py
@@ -6,7 +6,6 @@ from greenideas.rules.default_english_rules.attributes.default_english_attribute
 )
 from greenideas.rules.default_english_rules.attributes.npform import NPForm
 from greenideas.rules.default_english_rules.attributes.person import Person
-from greenideas.rules.default_english_rules.attributes.voice import Voice
 from greenideas.rules.default_english_rules.parts_of_speech.default_english_pos_types import (
     DefaultEnglishPOSType,
 )
@@ -43,9 +42,6 @@ s__np_vp = GrammarRule(
 s__np_auxp = GrammarRule(
     SourceSpec(
         DefaultEnglishPOSType.S,
-        {
-            DefaultEnglishAttributeType.VOICE: Voice.ACTIVE,
-        },
     ),
     [
         ExpansionSpec(

--- a/greenideas/rules/default_english_rules/expansions/vpAfterFrontedAux_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/vpAfterFrontedAux_expansions.py
@@ -182,7 +182,10 @@ vpAfterFA1_pp = GrammarRule(
             {
                 DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
                 DefaultEnglishAttributeType.TENSE: Tense.PAST,
-                DefaultEnglishAttributeType.VALENCY: INHERIT,
+                DefaultEnglishAttributeType.VALENCY: [
+                    Valency.DIVALENT,
+                    Valency.TRIVALENT,
+                ],
                 DefaultEnglishAttributeType.VOICE: Voice.ACTIVE,
             },
         ),
@@ -209,7 +212,10 @@ vpAfterFA1_progp = GrammarRule(
             DefaultEnglishPOSType.Verb,
             {
                 DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
-                DefaultEnglishAttributeType.VALENCY: INHERIT,
+                DefaultEnglishAttributeType.VALENCY: [
+                    Valency.DIVALENT,
+                    Valency.TRIVALENT,
+                ],
                 DefaultEnglishAttributeType.VOICE: Voice.ACTIVE,
             },
         ),
@@ -240,7 +246,10 @@ vpAfterFA1_ppp = GrammarRule(
             DefaultEnglishPOSType.Verb,
             {
                 DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
-                DefaultEnglishAttributeType.VALENCY: INHERIT,
+                DefaultEnglishAttributeType.VALENCY: [
+                    Valency.DIVALENT,
+                    Valency.TRIVALENT,
+                ],
                 DefaultEnglishAttributeType.VOICE: Voice.ACTIVE,
             },
         ),

--- a/greenideas/rules/default_english_rules/expansions/vpExistingAux_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/vpExistingAux_expansions.py
@@ -16,11 +16,11 @@ from greenideas.rules.expansion_spec import INHERIT, ExpansionSpec
 from greenideas.rules.grammar_rule import GrammarRule
 from greenideas.rules.source_spec import SourceSpec
 
-vpAfterFA__vpAfterFA_pp = GrammarRule(
-    SourceSpec(DefaultEnglishPOSType.VP_AfterFrontedAux),
+vpExistingAux__vpExistingAux_pp = GrammarRule(
+    SourceSpec(DefaultEnglishPOSType.VP_ExistingAux),
     [
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
@@ -34,11 +34,11 @@ vpAfterFA__vpAfterFA_pp = GrammarRule(
     ignore_after_depth=3,
 )
 
-vpAfterFA__vpAfterFA_advp = GrammarRule(
-    SourceSpec(DefaultEnglishPOSType.VP_AfterFrontedAux),
+vpExistingAux__vpExistingAux_advp = GrammarRule(
+    SourceSpec(DefaultEnglishPOSType.VP_ExistingAux),
     [
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
@@ -52,12 +52,12 @@ vpAfterFA__vpAfterFA_advp = GrammarRule(
     ignore_after_depth=3,
 )
 
-vpAfterFA__advP_vpAfterFA = GrammarRule(
-    SourceSpec(DefaultEnglishPOSType.VP_AfterFrontedAux),
+vpExistingAux__advP_vpExistingAux = GrammarRule(
+    SourceSpec(DefaultEnglishPOSType.VP_ExistingAux),
     [
         ExpansionSpec(DefaultEnglishPOSType.AdvP),
         ExpansionSpec(
-            DefaultEnglishPOSType.VP_AfterFrontedAux,
+            DefaultEnglishPOSType.VP_ExistingAux,
             {
                 DefaultEnglishAttributeType.ASPECT: INHERIT,
                 DefaultEnglishAttributeType.TENSE: INHERIT,
@@ -70,9 +70,9 @@ vpAfterFA__advP_vpAfterFA = GrammarRule(
     ignore_after_depth=3,
 )
 
-vpAfterFA1_simple = GrammarRule(
+vpExistingAux1_simple = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.SIMPLE,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -92,9 +92,9 @@ vpAfterFA1_simple = GrammarRule(
     ],
 )
 
-vpAfterFA1_pa = GrammarRule(
+vpExistingAux1_pa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -114,9 +114,9 @@ vpAfterFA1_pa = GrammarRule(
     ],
 )
 
-vpAfterFA1_proga = GrammarRule(
+vpExistingAux1_proga = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -135,9 +135,9 @@ vpAfterFA1_proga = GrammarRule(
     ],
 )
 
-vpAfterFA1_ppa = GrammarRule(
+vpExistingAux1_ppa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT_PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -161,9 +161,9 @@ vpAfterFA1_ppa = GrammarRule(
 )
 
 
-vpAfterFA1_pp = GrammarRule(
+vpExistingAux1_pp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -192,9 +192,9 @@ vpAfterFA1_pp = GrammarRule(
     ],
 )
 
-vpAfterFA1_progp = GrammarRule(
+vpExistingAux1_progp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -222,9 +222,9 @@ vpAfterFA1_progp = GrammarRule(
     ],
 )
 
-vpAfterFA1_ppp = GrammarRule(
+vpExistingAux1_ppp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT_PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.MONOVALENT,
@@ -256,9 +256,9 @@ vpAfterFA1_ppp = GrammarRule(
     ],
 )
 
-vpAfterFA2_simple = GrammarRule(
+vpExistingAux2_simple = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.SIMPLE,
             DefaultEnglishAttributeType.VALENCY: Valency.DIVALENT,
@@ -284,9 +284,9 @@ vpAfterFA2_simple = GrammarRule(
     ],
 )
 
-vpAfterFA2_pa = GrammarRule(
+vpExistingAux2_pa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: Valency.DIVALENT,
@@ -312,9 +312,9 @@ vpAfterFA2_pa = GrammarRule(
     ],
 )
 
-vpAfterFA2_proga = GrammarRule(
+vpExistingAux2_proga = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.DIVALENT,
@@ -339,9 +339,9 @@ vpAfterFA2_proga = GrammarRule(
     ],
 )
 
-vpAfterFA2_ppa = GrammarRule(
+vpExistingAux2_ppa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT_PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.DIVALENT,
@@ -366,9 +366,9 @@ vpAfterFA2_ppa = GrammarRule(
 
 
 # passive monovalents -> convert to divalent
-vpAfterFA2_pp = GrammarRule(
+vpExistingAux2_pp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: [Valency.MONOVALENT, Valency.DIVALENT],
@@ -394,9 +394,9 @@ vpAfterFA2_pp = GrammarRule(
     ],
 )
 
-vpAfterFA2_progp = GrammarRule(
+vpExistingAux2_progp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: [Valency.MONOVALENT, Valency.DIVALENT],
@@ -421,9 +421,9 @@ vpAfterFA2_progp = GrammarRule(
     ],
 )
 
-vpAfterFA2_ppp = GrammarRule(
+vpExistingAux2_ppp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.VALENCY: [Valency.MONOVALENT, Valency.DIVALENT],
             DefaultEnglishAttributeType.VOICE: Voice.PASSIVE,
@@ -451,9 +451,9 @@ vpAfterFA2_ppp = GrammarRule(
     ],
 )
 
-vpAfterFA3_simple = GrammarRule(
+vpExistingAux3_simple = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.SIMPLE,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -488,9 +488,9 @@ vpAfterFA3_simple = GrammarRule(
     ],
 )
 
-vpAfterFA3_pa = GrammarRule(
+vpExistingAux3_pa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -525,9 +525,9 @@ vpAfterFA3_pa = GrammarRule(
     ],
 )
 
-vpAfterFA3_proga = GrammarRule(
+vpExistingAux3_proga = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -561,9 +561,9 @@ vpAfterFA3_proga = GrammarRule(
     ],
 )
 
-vpAfterFA3_ppa = GrammarRule(
+vpExistingAux3_ppa = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT_PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -602,9 +602,9 @@ vpAfterFA3_ppa = GrammarRule(
 )
 
 
-vpAfterFA3_pp = GrammarRule(
+vpExistingAux3_pp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -638,9 +638,9 @@ vpAfterFA3_pp = GrammarRule(
     ],
 )
 
-vpAfterFA3_progp = GrammarRule(
+vpExistingAux3_progp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -673,9 +673,9 @@ vpAfterFA3_progp = GrammarRule(
     ],
 )
 
-vpAfterFA3_ppp = GrammarRule(
+vpExistingAux3_ppp = GrammarRule(
     SourceSpec(
-        DefaultEnglishPOSType.VP_AfterFrontedAux,
+        DefaultEnglishPOSType.VP_ExistingAux,
         {
             DefaultEnglishAttributeType.ASPECT: Aspect.PERFECT_PROGRESSIVE,
             DefaultEnglishAttributeType.VALENCY: Valency.TRIVALENT,
@@ -712,29 +712,29 @@ vpAfterFA3_ppp = GrammarRule(
     ],
 )
 
-vpAfterFA_expansions = [
-    vpAfterFA__vpAfterFA_advp,
-    vpAfterFA__advP_vpAfterFA,
-    vpAfterFA__vpAfterFA_pp,
-    vpAfterFA1_simple,
-    vpAfterFA1_pa,
-    vpAfterFA1_proga,
-    vpAfterFA1_ppa,
-    vpAfterFA1_pp,
-    vpAfterFA1_progp,
-    vpAfterFA1_ppp,
-    vpAfterFA2_simple,
-    vpAfterFA2_pa,
-    vpAfterFA2_proga,
-    vpAfterFA2_ppa,
-    vpAfterFA2_pp,
-    vpAfterFA2_progp,
-    vpAfterFA2_ppp,
-    vpAfterFA3_simple,
-    vpAfterFA3_pa,
-    vpAfterFA3_proga,
-    vpAfterFA3_ppa,
-    vpAfterFA3_pp,
-    vpAfterFA3_progp,
-    vpAfterFA3_ppp,
+vpExistingAux_expansions = [
+    vpExistingAux__vpExistingAux_advp,
+    vpExistingAux__advP_vpExistingAux,
+    vpExistingAux__vpExistingAux_pp,
+    vpExistingAux1_simple,
+    vpExistingAux1_pa,
+    vpExistingAux1_proga,
+    vpExistingAux1_ppa,
+    vpExistingAux1_pp,
+    vpExistingAux1_progp,
+    vpExistingAux1_ppp,
+    vpExistingAux2_simple,
+    vpExistingAux2_pa,
+    vpExistingAux2_proga,
+    vpExistingAux2_ppa,
+    vpExistingAux2_pp,
+    vpExistingAux2_progp,
+    vpExistingAux2_ppp,
+    vpExistingAux3_simple,
+    vpExistingAux3_pa,
+    vpExistingAux3_proga,
+    vpExistingAux3_ppa,
+    vpExistingAux3_pp,
+    vpExistingAux3_progp,
+    vpExistingAux3_ppp,
 ]

--- a/greenideas/rules/default_english_rules/expansions/vpPassive_expansions.py
+++ b/greenideas/rules/default_english_rules/expansions/vpPassive_expansions.py
@@ -110,6 +110,7 @@ vp2__passive_perf = GrammarRule(
             },
         ),
     ],
+    weight=1000,
 )
 
 # VP3_passive w/ NP.obj
@@ -228,6 +229,7 @@ vp3__passive_perf = GrammarRule(
             },
         ),
     ],
+    weight=1000,
 )
 vp_passive_expansions = [
     vp2__passive_simple,

--- a/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_attributes.py
+++ b/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_attributes.py
@@ -136,7 +136,7 @@ POSTYPE_ATTRIBUTE_MAP = {
         DefaultEnglishAttributeType.ASPECT,
         DefaultEnglishAttributeType.VALENCY,
     },
-    DefaultEnglishPOSType.VP_AfterFrontedAux: {
+    DefaultEnglishPOSType.VP_ExistingAux: {
         DefaultEnglishAttributeType.ASPECT,
         DefaultEnglishAttributeType.TENSE,
         DefaultEnglishAttributeType.VALENCY,

--- a/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_attributes.py
+++ b/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_attributes.py
@@ -29,6 +29,7 @@ POSTYPE_ATTRIBUTE_MAP = {
         DefaultEnglishAttributeType.NUMBER,
         DefaultEnglishAttributeType.PERSON,
         DefaultEnglishAttributeType.TENSE,
+        DefaultEnglishAttributeType.VOICE,
     },
     DefaultEnglishPOSType.Be: {
         DefaultEnglishAttributeType.ASPECT,

--- a/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_types.py
+++ b/greenideas/rules/default_english_rules/parts_of_speech/default_english_pos_types.py
@@ -18,7 +18,7 @@ class DefaultEnglishPOSType(POSType):
     PP = auto()
     RelClause = auto()
     VP = auto()
-    VP_AfterFrontedAux = auto()
+    VP_ExistingAux = auto()
     VP_AfterModal = auto()
     VP_Bare = auto()
     VP_Passive = auto()


### PR DESCRIPTION
Identify and adjust a rule which occasionally led to doubled auxiliaries, e.g.

Otters haven't haven't been defeated.

Also ensure we don't get monovalent verbs in passive forms after auxiliaries. 