### PR TITLE
fill sentence fragments to tree

### DIFF
--- a/greenideas/__main__.py
+++ b/greenideas/__main__.py
@@ -19,7 +19,7 @@ from greenideas.twaddle.twaddle_formatter import TwaddleFormatter
 
 def pretty_print_tree(tree: POSNode):
     indent = "\t" * tree.depth
-    print(f'{indent}-{tree.type}: "{tree.twaddle_result}"')
+    print(f'{indent}{tree.depth} - {tree.type}: "{tree.twaddle_result}"')
     for child in tree.children:
         pretty_print_tree(child)
 

--- a/greenideas/__main__.py
+++ b/greenideas/__main__.py
@@ -6,6 +6,7 @@ from importlib.resources import files
 from twaddle.runner import TwaddleRunner
 
 from greenideas.grammar_engine import GrammarEngine
+from greenideas.parts_of_speech.pos_node import POSNode
 from greenideas.rules.default_english_rules.default_rules import default_rules
 from greenideas.rules.default_english_rules.parts_of_speech.default_english_pos_types import (
     DefaultEnglishPOSType,
@@ -16,13 +17,20 @@ from greenideas.twaddle.default_formatters.default_formatting_handlers import (
 from greenideas.twaddle.twaddle_formatter import TwaddleFormatter
 
 
+def pretty_print_tree(tree: POSNode):
+    indent = "\t" * tree.depth
+    print(f'{indent}-{tree.type}: "{tree.twaddle_result}"')
+    for child in tree.children:
+        pretty_print_tree(child)
+
+
 def main():
     logging.basicConfig(filename="greenideas.log", level=logging.INFO)
     if len(sys.argv) < 2:
         dictionary_path = files("greenideas.default_dictionary")
     else:
         dictionary_path = sys.argv[1]
-    twaddle_runner = TwaddleRunner(dictionary_path)
+    twaddle_runner = TwaddleRunner(dictionary_path, persistent_clipboard=True)
 
     engine = GrammarEngine(default_rules)
     tree = engine.generate_tree(DefaultEnglishPOSType.Utterance)
@@ -32,9 +40,14 @@ def main():
     for type, handler in default_formatting_handlers.items():
         formatter.register_formatting_handler(type, handler)
 
-    twaddle_string = formatter.format_as_sentence(tree)
-    print(twaddle_string)
-    print(twaddle_runner.run_sentence(twaddle_string))
+    formatted_tree = formatter.format_as_sentence(tree)
+    display_twaddle_string = formatted_tree.display_twaddle_string
+    internal_twaddle_string = formatted_tree.internal_twaddle_string
+    print(display_twaddle_string)
+    print(twaddle_runner.run_sentence(internal_twaddle_string))
+    formatter.fill_twaddle_results(tree, twaddle_runner)
+
+    pretty_print_tree(tree)
 
 
 if __name__ == "__main__":

--- a/greenideas/parts_of_speech/pos_node.py
+++ b/greenideas/parts_of_speech/pos_node.py
@@ -14,6 +14,7 @@ class POSNode:
     space_follows: bool = True
     post_punctuation: Optional[str] = None
     pre_punctuation: Optional[str] = None
+    twaddle_result: Optional[str] = None
 
     def __str__(self):
         children = (

--- a/greenideas/twaddle/formatting_context.py
+++ b/greenideas/twaddle/formatting_context.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 @dataclass
 class FormattingContext:
-    value: str = ""
+    display_twaddle_string: str = ""
+    internal_twaddle_string: str = ""
     needs_space: bool = False
     queued_punctuation: Optional[str] = None

--- a/greenideas/twaddle/twaddle_formatter.py
+++ b/greenideas/twaddle/twaddle_formatter.py
@@ -87,12 +87,15 @@ class TwaddleFormatter:
             queued_punctuation=context.queued_punctuation,
         )
 
+    def get_trimmed_sentence(self, node: POSNode, runner: TwaddleRunner) -> str:
+        return runner.run_sentence(f"[paste:{id(node)}]").strip()
+
     def fill_twaddle_results(self, tree: POSNode, runner: TwaddleRunner):
         try:
             if not tree.twaddle_result:
-                tree.twaddle_result = runner.run_sentence(f"[paste:{id(tree)}]")
+                tree.twaddle_result = self.get_trimmed_sentence(tree, runner)
             for child in tree.children:
-                child.twaddle_result = runner.run_sentence(f"[paste:{id(child)}]")
+                child.twaddle_result = self.get_trimmed_sentence(child, runner)
                 self.fill_twaddle_results(child, runner)
         except TwaddleException as e:
             print(f"error: {str(e)}")

--- a/greenideas/twaddle/twaddle_formatter.py
+++ b/greenideas/twaddle/twaddle_formatter.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Optional
 
+from twaddle import TwaddleException, TwaddleRunner
+
 from greenideas.exceptions import TwaddleConversionError
 from greenideas.parts_of_speech.pos_node import POSNode
 from greenideas.parts_of_speech.pos_type_base import POSType
@@ -19,6 +21,12 @@ class TwaddleFormatter:
     ):
         self.formatting_handlers[pos] = handler
 
+    def _add_sentence_case(self, twaddle_string: str) -> str:
+        return f"[case:sentence]{twaddle_string}"
+
+    def _add_copy(self, twaddle_string: str, node: POSNode) -> str:
+        return f"[copy:{id(node)}]{{{twaddle_string}}}"
+
     def format_node(
         self, node: POSNode, context: Optional[FormattingContext] = None
     ) -> str:
@@ -31,8 +39,6 @@ class TwaddleFormatter:
                 f"Node has attributes: {node.attributes}"
             )
         tag = handler.format(node)
-        if context.needs_space:
-            tag = " " + tag
         return tag
 
     def format(
@@ -42,40 +48,70 @@ class TwaddleFormatter:
             raise TwaddleConversionError("Input must be a POSNode")
         if not context:
             context = FormattingContext()
-        twaddle_string = context.value
-        if node.pre_punctuation:
-            twaddle_string = node.pre_punctuation + twaddle_string
+        display_twaddle_string = context.display_twaddle_string
+        internal_twaddle_string = context.internal_twaddle_string
 
         if not node.children:
             context = FormattingContext(
                 needs_space=context.needs_space,
                 queued_punctuation=context.queued_punctuation,
             )
-            twaddle_string += self.format_node(node, context)
+            formatted_node = self.format_node(node, context)
+            if context.needs_space:
+                formatted_node = " " + formatted_node
+            display_twaddle_string += formatted_node
+            internal_twaddle_string = formatted_node
         else:
             for child in node.children:
                 if context.queued_punctuation:
-                    twaddle_string += context.queued_punctuation
+                    display_twaddle_string += context.queued_punctuation
                     context.queued_punctuation = None
-                twaddle_string += self.format(child, context).value
+                formatted_child = self.format(child, context)
+                copied_child = self._add_copy(
+                    formatted_child.internal_twaddle_string, child
+                )
+                display_twaddle_string += formatted_child.display_twaddle_string
+                internal_twaddle_string += copied_child
                 context.needs_space = child.space_follows
                 if child.post_punctuation:
                     context.queued_punctuation = child.post_punctuation
+        if node.pre_punctuation:
+            display_twaddle_string = node.pre_punctuation + display_twaddle_string
+            internal_twaddle_string = node.pre_punctuation + internal_twaddle_string
         if node.post_punctuation:
             context.queued_punctuation = node.post_punctuation
         return FormattingContext(
-            value=twaddle_string,
+            display_twaddle_string=display_twaddle_string,
+            internal_twaddle_string=internal_twaddle_string,
             needs_space=context.needs_space,
             queued_punctuation=context.queued_punctuation,
         )
 
-    def format_as_sentence(self, tree: POSNode) -> str:
+    def fill_twaddle_results(self, tree: POSNode, runner: TwaddleRunner):
+        try:
+            if not tree.twaddle_result:
+                tree.twaddle_result = runner.run_sentence(f"[paste:{id(tree)}]")
+            for child in tree.children:
+                child.twaddle_result = runner.run_sentence(f"[paste:{id(child)}]")
+                self.fill_twaddle_results(child, runner)
+        except TwaddleException as e:
+            print(f"error: {str(e)}")
+            logger.error(f"Encountered an error filling Twaddle results: {str(e)}")
+
+    def format_as_sentence(self, tree: POSNode) -> FormattingContext:
         if not isinstance(tree, POSNode):
             raise TwaddleConversionError("Input must be a POSNode")
-        top_level_context = self.format(tree)
-        twaddle_string = top_level_context.value
-        if top_level_context.queued_punctuation:
-            twaddle_string += top_level_context.queued_punctuation
-        result = f"[case:sentence]{twaddle_string}"
-        logger.info(result)
-        return result
+        context = self.format(tree)
+        context.display_twaddle_string = self._add_sentence_case(
+            context.display_twaddle_string
+        )
+        context.internal_twaddle_string = self._add_sentence_case(
+            context.internal_twaddle_string
+        )
+        if context.queued_punctuation:
+            context.display_twaddle_string += context.queued_punctuation
+            context.internal_twaddle_string += context.queued_punctuation
+        context.internal_twaddle_string = self._add_copy(
+            context.internal_twaddle_string, tree
+        )
+        return context

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,26 +15,26 @@ files = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
-    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
-    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 
 [[package]]
@@ -55,14 +55,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -105,4 +105,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "b8f0a897814f91b4dbedf1af855d1d6593c228d82608eedcb863354d28066cc3"
+content-hash = "36d42b1e5ddd296eedb8d36f280dc2fbb95f88d2efb8954a4fab2f008ad9e64c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,14 +70,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
 ]
 
 [package.dependencies]
@@ -92,18 +92,15 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "twaddle"
-version = "1.2.2"
+version = "1.10.0"
 description = "Text generation and templating"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "twaddle-1.2.2-py3-none-any.whl", hash = "sha256:ef1e731a184f1b9713af7e8aa1ae9a45d8f3a0c2f2059f9ec4851a562e67b9ec"},
-    {file = "twaddle-1.2.2.tar.gz", hash = "sha256:2617f731dccd564b99ec7ccfc82c66458f26745ca74845a88aee61a4ac2c5db4"},
+    {file = "twaddle-1.10.0-py3-none-any.whl", hash = "sha256:4376e5b2d6fba7c8e50c2a342ee499b4c30037becfd443f1b8d52505f5a65227"},
+    {file = "twaddle-1.10.0.tar.gz", hash = "sha256:ad2d4bc1152dc534dd7ad2c179b4c7fa957577ab1472482f7476866926972d87"},
 ]
-
-[package.dependencies]
-pytest = ">=7.2.0"
 
 [metadata]
 lock-version = "2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "greenideas"
-version = "0.10.0"
+version = "1.0.0"
 description = "A package to generate grammatically valid but semantically nonsensical English sentences."
 authors = [
     {name = "Chris Hengler",email = "chrysics@gmail.com"}
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pytest (>=7.2.0)",
-    "twaddle (>=1.2.2)"
+    "twaddle (>=1.10.0)"
 ]
 keywords = ["grammar", "procedural generation", "sentence generation", "placeholder text", "twaddle"]
     

--- a/tests/test_twaddle_formatter.py
+++ b/tests/test_twaddle_formatter.py
@@ -49,7 +49,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             type=DefaultEnglishPOSType.S, children=[noun_phrase, verb_phrase]
         )
         expected_template = "<det.sg> <noun.sg> <verb-monovalent.s> <det.sg> <noun.sg>"
-        result = self.formatter.format(sentence).value
+        result = self.formatter.format(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_format_as_sentence(self):
@@ -80,7 +80,7 @@ class TestTwaddleFormatter(unittest.TestCase):
         expected_template = (
             "[case:sentence]<det.sg> <noun.sg> <verb-monovalent.s> <det.sg> <noun.sg>."
         )
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_format_with_and_without_spacing(self):
@@ -104,7 +104,7 @@ class TestTwaddleFormatter(unittest.TestCase):
         )
         sentence = POSNode(type=DefaultEnglishPOSType.S, children=[det, noun, verb])
         expected_template = "[case:sentence]<det.sg> <noun.sg><verb-monovalent.s>"
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_format_single_node_with_punctuation(self):
@@ -115,7 +115,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             post_punctuation="!",
         )
         expected_template = "[case:sentence]...<noun.pl>!"
-        result = self.formatter.format_as_sentence(node)
+        result = self.formatter.format_as_sentence(node).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_terminal_punctuation_not_top_level(self):
@@ -131,7 +131,7 @@ class TestTwaddleFormatter(unittest.TestCase):
         )
         sentence = POSNode(type=DefaultEnglishPOSType.S, children=[verb])
         expected_template = "[case:sentence]<verb-monovalent.s>!"
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_with_spacing_and_punctuation(self):
@@ -157,7 +157,7 @@ class TestTwaddleFormatter(unittest.TestCase):
         )
         sentence = POSNode(type=DefaultEnglishPOSType.S, children=[det, noun, verb])
         expected_template = "[case:sentence]!<det.sg> <noun.sg>, <verb-monovalent.s>!"
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_parent_node_post_punctuation(self):
@@ -211,7 +211,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             children=[noun_phrase_with_rel_clause, verb_phrase],
             post_punctuation=".",
         )
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         expected_template = (
             "[case:sentence]<det.sg> <noun.sg>, <rel-animate> <verb-monovalent.past>, "
             "<verb-monovalent.s> <det.sg> <noun.sg>."
@@ -250,7 +250,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             children=[noun_phrase, verb_phrase],
         )
         expected_template = "[case:sentence]!<det.sg> <noun.sg>, <verb-monovalent.s> <det.sg> <noun.sg>?"
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         self.assertEqual(result, expected_template)
 
     def test_post_punctuation_pileup(self):
@@ -304,7 +304,7 @@ class TestTwaddleFormatter(unittest.TestCase):
             children=[noun_phrase, verb_phrase],
             post_punctuation=".",
         )
-        result = self.formatter.format_as_sentence(sentence)
+        result = self.formatter.format_as_sentence(sentence).display_twaddle_string
         expected_template = (
             "[case:sentence]<det.sg> <noun.sg> <verb-monovalent.s> <det.sg> "
             "<noun.sg>, <rel-animate> <verb-monovalent.past>."


### PR DESCRIPTION
Adds `[copy]` tags based on `id(node)` to an internal Twaddle string, which can then be used to fill in the corresponding sentence fragment to each node.